### PR TITLE
Stabilize Debian branch of the role to not pull from unstable

### DIFF
--- a/tasks/requirements_debian.yml
+++ b/tasks/requirements_debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add unstable package sources
   apt_repository:
-    repo: deb http://ftp.de.debian.org/debian unstable main
+    repo: deb http://ftp.de.debian.org/debian buster main
     state: present
   tags:
     - pretalx
@@ -10,7 +10,7 @@
   apt:
     name: "{{ item }}"
     state: latest
-    default_release: unstable
+    default_release: buster
   with_items:
     - python3.6
     - python3-pip


### PR DESCRIPTION
This commit changes the default source for python 3.6 to the least
invasive source repository, which is not Debian unstable, but, at the time of the
commit, testing. To ensure the role doesn't pull testing in
unnecessarily, we use the release name, such that once buster gets
releasted as the stable distribution, the role still works as intended
and will continue doing so at least for the time of buster being the
stable release of Debian GNU/Linux.