### PR TITLE
Disable ansible-lint check for comparison with emptystring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ language: python
 python: "2.7"
 install:
   - pip install ansible-lint
-script: ansible-lint -x ANSIBLE0010 .
+script: ansible-lint -x ANSIBLE0010 -x 602 .


### PR DESCRIPTION
Looking at https://github.com/ansible/ansible-lint/issues/457
this is currently broken in Ansible, as emptystring cannot be
checked the same way as in Python.

So disable the check and continue testing for emptystring as is.