### PR TITLE
Update Debian build to work on latest Stretch

### DIFF
--- a/tasks/requirements_debian.yml
+++ b/tasks/requirements_debian.yml
@@ -36,6 +36,7 @@
       - gcc
       - gettext
       - git
+      - redis-server
       - sqlite3
     state: present
   tags:

--- a/tasks/requirements_debian.yml
+++ b/tasks/requirements_debian.yml
@@ -8,21 +8,31 @@
 
 - name: Install Python 3.6
   apt:
-    name: "{{ item }}"
+    name:
+      - python3.6
+      - python3-pip
     state: latest
     default_release: buster
-  with_items:
-    - python3.6
-    - python3-pip
+  tags:
+    - pretalx
+
+- name: Install python-setuptools if Ansible is running with Python 2
+  # The Ansible pip module needs setuptools available in the Python version
+  # under which Ansible is running.
+  # See https://github.com/ansible/ansible/issues/47361#issuecomment-433892723
+  # for a more detailed explaination.
+  apt:
+    name: python-setuptools
+    state: present
+  when: ansible_python.version.major|int == 2
   tags:
     - pretalx
 
 - name: Install other dependencies
   apt:
-    name: "{{ item }}"
+    name:
+      - git
+      - sqlite3
     state: present
-  with_items:
-    - git
-    - sqlite3
   tags:
     - pretalx

--- a/tasks/requirements_debian.yml
+++ b/tasks/requirements_debian.yml
@@ -10,7 +10,9 @@
   apt:
     name:
       - python3.7
+      - python3.7-dev
       - python3-pip
+      - python3-wheel
     state: latest
     default_release: buster
   tags:
@@ -31,6 +33,8 @@
 - name: Install other dependencies
   apt:
     name:
+      - gcc
+      - gettext
       - git
       - sqlite3
     state: present

--- a/tasks/requirements_debian.yml
+++ b/tasks/requirements_debian.yml
@@ -6,10 +6,10 @@
   tags:
     - pretalx
 
-- name: Install Python 3.6
+- name: Install Python 3.7
   apt:
     name:
-      - python3.6
+      - python3.7
       - python3-pip
     state: latest
     default_release: buster


### PR DESCRIPTION
Debian has updated its Python to version 3.7 so we need to update our references accordingly.

Also, installation on Debian results in the building of wheels and the compilation of some modules implemented in C, so we should ensure that the build dependencies are all available.

Finally, we should ensure that the Arch Linux and the Debian installation are in sync, therefore, Redis server should also be installed on Debian.