### PR TITLE
feat: add `pretalx_nginx_http_only` mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,7 @@ pretalx_mail_ssl: "True"
 pretalx_nginx: false
 pretalx_nginx_path: false
 pretalx_nginx_force_https: false  # Set to true if you want this role to take care of HTTPS upgrades, leave false if your nginx configuration handles this already
+pretalx_nginx_http_only: false
 
 pretalx_redis: false
 

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -14,6 +14,15 @@ server {
 }
 {% endif %}
 
+{% if pretalx_nginx_http_only %}
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name {{ pretalx_domain }}{% if pretalx_alternate_domains %} {{ pretalx_alternate_domains }}{% endif %};
+
+{% else %}
+
 server {
     listen 443 ssl;
     listen [::]:443 ssl;
@@ -23,12 +32,14 @@ server {
     ssl on;
     ssl_certificate {{ pretalx_cert_root }}/{{ pretalx_domain }}/fullchain.pem;
     ssl_certificate_key {{ pretalx_cert_root }}/{{ pretalx_domain }}/privkey.pem;
+    proxy_set_header X-Forwarded-Proto https;
+
+{% endif %}
 
     access_log  /var/log/nginx/pretalx_{{ pretalx_instance_identifier }}.access.log;
     error_log   /var/log/nginx/pretalx_{{ pretalx_instance_identifier }}.error.log;
 
     proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
     location /static/ {


### PR DESCRIPTION
Added a flag `pretalx_nginx_http_only` to allow for Nginx serving the app at port 80, allowing you to use another reverse proxy for TLS termination.