### PR TITLE
bump default to python 3.9 and fix debian install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 pretalx_instance_identifier: "event"  # used if you have more than one instance on your server
 
-pretalx_system_python_version: "3.7"
+pretalx_system_python_version: "3.9"
 
 pretalx_database_backend: postgresql
 pretalx_database_name: pretalx{{ pretalx_instance_identifier }}

--- a/tasks/requirements_debian.yml
+++ b/tasks/requirements_debian.yml
@@ -6,11 +6,11 @@
   tags:
     - pretalx
 
-- name: Install Python 3.7
+- name: Install Python 3
   apt:
     name:
-      - python3.7
-      - python3.7-dev
+      - python3
+      - python3-dev
       - python3-pip
       - python3-wheel
     state: latest


### PR DESCRIPTION
There was two bugs:
- first, when installing on Debian, you hardcode that you install python3.7 even though a python variable version exists. Debian 11 is now at 3.9.
- furthermore, 3.7 is not even available anymore on Debian 11 so I changed the default.

I'm pretty sure it fixes https://github.com/pretalx/ansible-pretalx/issues/17 since I had the exact same problem