### PR TITLE
Remove adding obsolete buster sources

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,7 @@ pretalx_celery_broker: "redis://127.0.0.1:6379/2"
 
 pretalx_version: latest
 pretalx_git_version: ""
+pretalx_git_url: "git://github.com/pretalx/pretalx.git"
 
 pretalx_plugins: null
 

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -3,6 +3,7 @@
   user:
     name: "{{ pretalx_system_user }}"
     state: present
+    system: true
   tags:
     - pretalx
 

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -132,7 +132,7 @@
 
 - name: Install pretalx (git)
   pip:
-    name: "git+git://github.com/pretalx/pretalx.git@{{ pretalx_git_version }}#egg=pretalx{{ pretalx_extra }}&subdirectory=src"
+    name: "git+{{ pretalx_git_url }}@{{ pretalx_git_version }}#egg=pretalx{{ pretalx_extra }}&subdirectory=src"
     executable: pip3
     extra_args: --user
     state: latest

--- a/tasks/requirements_debian.yml
+++ b/tasks/requirements_debian.yml
@@ -1,11 +1,4 @@
 ---
-- name: Add unstable package sources
-  apt_repository:
-    repo: deb http://ftp.de.debian.org/debian buster main
-    state: present
-  tags:
-    - pretalx
-
 - name: Install Python 3
   apt:
     name:
@@ -15,18 +8,6 @@
       - python3-wheel
     state: latest
     default_release: buster
-  tags:
-    - pretalx
-
-- name: Install python-setuptools if Ansible is running with Python 2
-  # The Ansible pip module needs setuptools available in the Python version
-  # under which Ansible is running.
-  # See https://github.com/ansible/ansible/issues/47361#issuecomment-433892723
-  # for a more detailed explaination.
-  apt:
-    name: python-setuptools
-    state: present
-  when: ansible_python.version.major|int == 2
   tags:
     - pretalx
 

--- a/tasks/requirements_debian.yml
+++ b/tasks/requirements_debian.yml
@@ -7,7 +7,6 @@
       - python3-pip
       - python3-wheel
     state: latest
-    default_release: buster
   tags:
     - pretalx
 

--- a/templates/pretalx.cfg.j2
+++ b/templates/pretalx.cfg.j2
@@ -38,7 +38,7 @@ broker = {{ pretalx_celery_broker }}{% endif %}
 {% if pretalx_redis %}
 [redis]
 location = {{ pretalx_redis }}
-sessions = True
+session = True
 {% endif %}
 
 {% if pretalx_admin_mail %}


### PR DESCRIPTION
Adding Python from a different repo than main is never a good idea, and now that buster is supserseded by bullseye, you definitely don't want it.