### PR TITLE
BREAKING CHANGE: fix: update default branch to install plugins from

### DIFF
--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -166,7 +166,7 @@
   git:
     repo: "{{ item.repository }}"
     dest: ~{{ pretalx_system_user }}/plugins/{{ item.name }}
-    version: master
+    version: "{{ item.version if item.version is defined else 'main' }}"
     key_file: ~{{ pretalx_system_user }}/.ssh/id_rsa
     accept_hostkey: yes
   become: true


### PR DESCRIPTION
Change the default branch to install plugins from to `main`, but also enable to change it to any other branch or tag.

fix #24 