### PR TITLE
fix: the `minute` parameter of `ansible.builtin.cron` module should be string

### DIFF
--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -259,7 +259,7 @@
 
 - name: Install runperiodic cronjob
   cron:
-    minute: 40
+    minute: "40"
     name: Run pretalx{{ pretalx_instance_identifier }} periodic task
     user: "{{ pretalx_system_user }}"
     job: "python{{ pretalx_system_python_version }} -m pretalx runperiodic"


### PR DESCRIPTION
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/cron_module.html#parameter-minute

The current code produces a warning during application, that a conversion happened from int to string.