### PR TITLE
fix: update Debian version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,5 +19,5 @@ galaxy_info:
         - all
     - name: Debian
       versions:
-        - stretch
+        - bullseye
   dependencies: []


### PR DESCRIPTION
The default Python in variables (3.9) is the version in Debian Bullseye, see https://packages.debian.org/bullseye/python3. Both Stretch and Buster have older versions of `python3`.

Debian Bookworm would include Python 3.11 (see https://packages.debian.org/bookworm/python3), not 3.10, which is mentioned in #22.