### PR TITLE
feat: detect Python version automatically

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,6 @@
 ---
 pretalx_instance_identifier: "event"  # used if you have more than one instance on your server
 
-pretalx_system_python_version: "3.9"
-
 pretalx_database_backend: postgresql
 pretalx_database_name: pretalx{{ pretalx_instance_identifier }}
 pretalx_database_user: pretalx{{ pretalx_instance_identifier }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,21 @@
 ---
 - name: Install system requirements
   import_tasks: requirements.yml
+
+- name: Detect installed system Python version
+  command: python3 -c "import sys; (major, minor) = sys.version_info[0:2]; print(f'{major}.{minor}')
+  args:
+    creates: nothing
+  changed_when: false
+  become: true
+  become_user: "{{ pretalx_system_user }}"
+  when: pretalx_system_python_version is not defined
+  register: pretalx_python_version_info_major_minor
+
+- name: Define installed system Python version variable
+  set_fact:
+    pretalx_system_python_version: "{{ pretalx_python_version_info_major_minor.stdout }}"
+  when: pretalx_system_python_version is not defined
+
 - name: Install pretalx itself
   import_tasks: package.yml


### PR DESCRIPTION
Detects specific version of Python installed as requirement in the previous tasks. Only run if `pretalx_system_python_version` is not specified, so this should have no effect on existing playbooks, where a specific version of Python might be specified up for a reason on systems which allow multiple Python 3 versions installed simultaneously.

fix #22 