### PR TITLE
fix: do not update system Debian packages once installed

### DIFF
--- a/tasks/requirements_debian.yml
+++ b/tasks/requirements_debian.yml
@@ -6,7 +6,7 @@
       - python3-dev
       - python3-pip
       - python3-wheel
-    state: latest
+    state: present
   tags:
     - pretalx
 


### PR DESCRIPTION
There might be other application that could break if Python gets updated as a side-effect of this role. If Python 3 is already present in the system, the role should not be updating it each time it's run.