### PR TITLE
feat: configurable system username prefix

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 pretalx_instance_identifier: "event"  # used if you have more than one instance on your server
 
+pretalx_system_user_prefix: "pretalx_"
+
 pretalx_database_backend: postgresql
 pretalx_database_name: pretalx{{ pretalx_instance_identifier }}
 pretalx_database_user: pretalx{{ pretalx_instance_identifier }}

--- a/templates/pretalx-worker.service.j2
+++ b/templates/pretalx-worker.service.j2
@@ -3,11 +3,11 @@ Description=pretalx %I background worker
 After=network.target
 
 [Service]
-User=pretalx_%i
-Group=pretalx_%i
-WorkingDirectory=/home/pretalx_%i/.local/lib/python{{ pretalx_system_python_version }}/site-packages/pretalx
-ExecStart=/home/pretalx_%i/.local/bin/celery -A pretalx.celery_app worker -l info
-WorkingDirectory=/home/pretalx_%i
+User={{ pretalx_system_user_prefix }}%i
+Group={{ pretalx_system_user_prefix }}%i
+WorkingDirectory=/home/{{ pretalx_system_user_prefix }}%i/.local/lib/python{{ pretalx_system_python_version }}/site-packages/pretalx
+ExecStart=/home/{{ pretalx_system_user_prefix }}%i/.local/bin/celery -A pretalx.celery_app worker -l info
+WorkingDirectory=/home/{{ pretalx_system_user_prefix }}%i
 Restart=on-failure
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID

--- a/templates/pretalx.service.j2
+++ b/templates/pretalx.service.j2
@@ -4,9 +4,9 @@ Requires=pretalx@%i.socket
 After=network.target
 
 [Service]
-User=pretalx_%i
-Group=pretalx_%i
-WorkingDirectory=/home/pretalx_%i/.local/lib/python{{ pretalx_system_python_version }}/site-packages/pretalx
-ExecStart=/home/pretalx_%i/.local/bin/gunicorn --bind unix:/run/gunicorn/pretalx_%i --workers 4  --max-requests 1200  --max-requests-jitter 50 pretalx.wsgi
+User={{ pretalx_system_user_prefix }}%i
+Group={{ pretalx_system_user_prefix }}%i
+WorkingDirectory=/home/{{ pretalx_system_user_prefix }}%i/.local/lib/python{{ pretalx_system_python_version }}/site-packages/pretalx
+ExecStart=/home/{{ pretalx_system_user_prefix }}%i/.local/bin/gunicorn --bind unix:/run/gunicorn/pretalx_%i --workers 4  --max-requests 1200  --max-requests-jitter 50 pretalx.wsgi
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pretalx_system_user: pretalx_{{ pretalx_instance_identifier }}
-pretalx_system_group: pretalx_{{ pretalx_instance_identifier }}
+pretalx_system_user: {{pretalx_system_user_prefix }}{{ pretalx_instance_identifier }}
+pretalx_system_group: {{ pretalx_system_user }}
 pretalx_system_home: /home/{{ pretalx_system_user }}
 pretalx_cert_root: /etc/ssl/letsencrypt/certs

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,4 @@
 ---
 pretalx_system_user: {{pretalx_system_user_prefix }}{{ pretalx_instance_identifier }}
-pretalx_system_group: {{ pretalx_system_user }}
 pretalx_system_home: /home/{{ pretalx_system_user }}
 pretalx_cert_root: /etc/ssl/letsencrypt/certs


### PR DESCRIPTION
The system username can now be configured to be whatever, given the instance identifier would be the same.

fix #29