### PR TITLE
feat: configurable SSL for Nginx

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,7 @@ pretalx_mail_ssl: "True"
 pretalx_nginx: false
 pretalx_nginx_path: false
 pretalx_nginx_force_https: false  # Set to true if you want this role to take care of HTTPS upgrades, leave false if your nginx configuration handles this already
+pretalx_nginx_cert_root: /etc/ssl/letsencrypt/certs
 pretalx_nginx_http_only: false
 
 pretalx_redis: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ pretalx_mail_ssl: "True"
 pretalx_nginx: false
 pretalx_nginx_path: false
 pretalx_nginx_force_https: false  # Set to true if you want this role to take care of HTTPS upgrades, leave false if your nginx configuration handles this already
-pretalx_nginx_cert_root: /etc/ssl/letsencrypt/certs
+pretalx_cert_root: /etc/ssl/letsencrypt/certs  # for Nginx configuration
 pretalx_nginx_http_only: false
 
 pretalx_redis: false

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -30,8 +30,8 @@ server {
     server_name {{ pretalx_domain }}{% if pretalx_alternate_domains %} {{ pretalx_alternate_domains }}{% endif %};
 
     ssl on;
-    ssl_certificate {{ pretalx_nginx_cert_root }}/{{ pretalx_domain }}/fullchain.pem;
-    ssl_certificate_key {{ pretalx_nginx_cert_root }}/{{ pretalx_domain }}/privkey.pem;
+    ssl_certificate {{ pretalx_cert_root }}/{{ pretalx_domain }}/fullchain.pem;
+    ssl_certificate_key {{ pretalx_cert_root }}/{{ pretalx_domain }}/privkey.pem;
     proxy_set_header X-Forwarded-Proto https;
 
 {% endif %}

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -4,7 +4,7 @@ upstream pretalx_{{ pretalx_instance_identifier }}_server {
 
 proxy_cache_path /tmp/nginx-pretalx-{{ pretalx_instance_identifier }} levels=1:2 keys_zone=pretalx_static_{{ pretalx_instance_identifier }}:10m inactive=60m max_size=250m;
 
-{% if pretalx_nginx_force_https %}
+{% if pretalx_nginx_force_https and not pretalx_nginx_http_only %}
 server {
     listen 80;
     listen [::]:80;
@@ -30,8 +30,8 @@ server {
     server_name {{ pretalx_domain }}{% if pretalx_alternate_domains %} {{ pretalx_alternate_domains }}{% endif %};
 
     ssl on;
-    ssl_certificate {{ pretalx_cert_root }}/{{ pretalx_domain }}/fullchain.pem;
-    ssl_certificate_key {{ pretalx_cert_root }}/{{ pretalx_domain }}/privkey.pem;
+    ssl_certificate {{ pretalx_nginx_cert_root }}/{{ pretalx_domain }}/fullchain.pem;
+    ssl_certificate_key {{ pretalx_nginx_cert_root }}/{{ pretalx_domain }}/privkey.pem;
     proxy_set_header X-Forwarded-Proto https;
 
 {% endif %}
@@ -78,4 +78,3 @@ server {
 
     client_max_body_size 32M;
 }
-

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,3 @@
 ---
-pretalx_system_user: "{{pretalx_system_user_prefix }}{{ pretalx_instance_identifier }}"
+pretalx_system_user: "{{ pretalx_system_user_prefix }}{{ pretalx_instance_identifier }}"
 pretalx_system_home: "/home/{{ pretalx_system_user }}"
-pretalx_cert_root: /etc/ssl/letsencrypt/certs


### PR DESCRIPTION
Replace 'pretalx_cert_root' by default 'pretalx_nginx_cert_root' for easier override. Also remove HTTPS redirect in case 'pretalx_nginx_http_only' is set.