### PR TITLE
fix: https protocol in default git URL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,7 +45,7 @@ pretalx_celery_broker: "redis://127.0.0.1:6379/2"
 
 pretalx_version: latest
 pretalx_git_version: ""
-pretalx_git_url: "git://github.com/pretalx/pretalx.git"
+pretalx_git_url: "https://github.com/pretalx/pretalx.git"
 
 pretalx_plugins: null
 


### PR DESCRIPTION
The `pretalx_git_url` variable is then prepended by `git+`. If `pretalx_git_url` schema was `git://`, the whole URL had schema `git+git://`, which pip (20.3.4, Python 3.9.2) could not connect to the GitHub repository.