### PR TITLE
Don't set default mail user/password

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,8 @@ pretalx_mail_port: 25
 
 pretalx_mail_tls: "False"
 pretalx_mail_ssl: "True"
+pretalx_mail_user: None # if set to None do not use authentication
+pretalx_mail_password: None
 
 pretalx_service_workers: 4  # https://docs.gunicorn.org/en/stable/settings.html?highlight=max-requests#workers
 pretalx_service_workers_max_requests: 1200  # https://docs.gunicorn.org/en/stable/settings.html?highlight=max-requests#max-requests

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,8 +22,7 @@ pretalx_admin_mail: ""
 pretalx_mail_from: admin@localhost
 pretalx_mail_host: localhost
 pretalx_mail_port: 25
-pretalx_mail_user: admin
-pretalx_mail_password: password
+
 pretalx_mail_tls: "False"
 pretalx_mail_ssl: "True"
 


### PR DESCRIPTION
It should be possible to connect to a mail server without username and password (on localhost/local network).

This is part of the template, but because these variables are set as default they will always be included