### PR TITLE
Use virtualenv instead of user pip

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@ pretalx_database_port: 5432
 pretalx_staticfiles_directory: /usr/share/webapps/pretalx{{ pretalx_instance_identifier }}/static/
 pretalx_data_dir: /usr/share/webapps/pretalx{{ pretalx_instance_identifier }}/data/
 pretalx_media_dir: /usr/share/webapps/pretalx{{ pretalx_instance_identifier }}/media/
+pretalx_python: "{{ pretalx_virtualenv }}/bin/virtualenv"
+pretalx_virtualenv: /usr/share/webapps/pretalx{{ pretalx_instance_identifier }}/venv/
 pretalx_webserver_group: http
 pretalx_domain: localhost
 pretalx_url: https://{{ pretalx_domain }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,8 +13,8 @@ pretalx_database_port: 5432
 pretalx_staticfiles_directory: /usr/share/webapps/pretalx{{ pretalx_instance_identifier }}/static/
 pretalx_data_dir: /usr/share/webapps/pretalx{{ pretalx_instance_identifier }}/data/
 pretalx_media_dir: /usr/share/webapps/pretalx{{ pretalx_instance_identifier }}/media/
-pretalx_python: "{{ pretalx_virtualenv }}/bin/virtualenv"
 pretalx_virtualenv: /usr/share/webapps/pretalx{{ pretalx_instance_identifier }}/venv/
+pretalx_python: "{{ pretalx_virtualenv }}/bin/virtualenv"
 pretalx_webserver_group: http
 pretalx_domain: localhost
 pretalx_url: https://{{ pretalx_domain }}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,20 +4,20 @@
     daemon_reload: true
 
 - name: Install pretalx plugins
-  shell: cd {{ pretalx_system_home }}/plugins/{{ item.name }} && python{{ pretalx_system_python_version }} setup.py develop --user
+  shell: cd {{ pretalx_system_home }}/plugins/{{ item.name }} && {{ pretalx_python }} setup.py develop --user
   with_items: "{{ pretalx_plugins }}"
   become: true
   become_user: "{{ pretalx_system_user }}"
   changed_when: true
 
 - name: Run pretalx migrations
-  command: python{{ pretalx_system_python_version }} -m pretalx migrate
+  command: "{{ pretalx_python }} -m pretalx migrate"
   become: true
   become_user: "{{ pretalx_system_user }}"
   changed_when: true
 
 - name: Compile pretalx styles
-  command: python{{ pretalx_system_python_version }} -m pretalx regenerate_css
+  command: "{{ pretalx_python }} -m pretalx regenerate_css"
   become: true
   become_user: "{{ pretalx_system_user }}"
   changed_when: true
@@ -30,7 +30,7 @@
   changed_when: true
 
 - name: Rebuild pretalx files
-  command: python{{ pretalx_system_python_version }} -m pretalx rebuild --npm-install
+  command: "{{ pretalx_python }} -m pretalx rebuild --npm-install"
   become: true
   become_user: "{{ pretalx_system_user }}"
   changed_when: true

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -126,7 +126,7 @@
 - name: Install pretalx (git)
   pip:
     name: "git+{{ pretalx_git_url }}@{{ pretalx_git_version }}#egg=pretalx{{ pretalx_extra }}"
-    state: latest  # noqa package-latest
+    state: forcereinstall
     virtualenv: "{{ pretalx_virtualenv }}"
   notify:
     - Restart pretalx service

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -19,15 +19,15 @@
     - "{{ pretalx_staticfiles_directory }}"
     - "{{ pretalx_data_dir }}"
     - "{{ pretalx_media_dir }}"
+    - "{{ pretalx_virtualenv }}"
   tags:
     - pretalx
 
 - name: Install redis client
   pip:
     name: django_redis
-    executable: pip3
-    extra_args: --user
     state: latest  # noqa package-latest
+    virtualenv: "{{ pretalx_virtualenv }}"
   become: true
   become_user: "{{ pretalx_system_user }}"
   when: pretalx_redis or pretalx_celery
@@ -38,9 +38,8 @@
 - name: Install gunicorn
   pip:
     name: gunicorn
-    executable: pip3
-    extra_args: --user
     state: latest  # noqa package-latest
+    virtualenv: "{{ pretalx_virtualenv }}"
   become: true
   become_user: "{{ pretalx_system_user }}"
   tags:
@@ -91,9 +90,8 @@
 - name: Install pretalx (latest)
   pip:
     name: "pretalx{{ pretalx_extra }}"
-    executable: pip3
-    extra_args: --user
     state: latest  # noqa package-latest
+    virtualenv: "{{ pretalx_virtualenv  }}"
   notify:
     - Restart pretalx service
     - Restart worker service
@@ -110,9 +108,8 @@
 - name: Install pretalx (versioned)
   pip:
     name: "pretalx{{ pretalx_extra }}"
-    executable: pip3
-    extra_args: --user
-    version: "{{ pretalx_version }}"
+    version: "{{ pretalx_version }}"  # noqa package-lastest
+    virtualenv: "{{ pretalx_virtualenv }}"
   notify:
     - Restart pretalx service
     - Restart worker service
@@ -129,9 +126,8 @@
 - name: Install pretalx (git)
   pip:
     name: "git+{{ pretalx_git_url }}@{{ pretalx_git_version }}#egg=pretalx{{ pretalx_extra }}"
-    executable: pip3
-    extra_args: --user
     state: latest  # noqa package-latest
+    virtualenv: "{{ pretalx_virtualenv }}"
   notify:
     - Restart pretalx service
     - Restart worker service
@@ -256,7 +252,7 @@
     minute: "40"
     name: Run pretalx{{ pretalx_instance_identifier }} periodic task
     user: "{{ pretalx_system_user }}"
-    job: "python{{ pretalx_system_python_version }} -m pretalx runperiodic"
+    job: "{{ pretalx_python }} -m pretalx runperiodic"
   when: pretalx_cron
   tags:
     - pretalx

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -91,7 +91,7 @@
   pip:
     name: "pretalx{{ pretalx_extra }}"
     state: latest  # noqa package-latest
-    virtualenv: "{{ pretalx_virtualenv  }}"
+    virtualenv: "{{ pretalx_virtualenv }}"
   notify:
     - Restart pretalx service
     - Restart worker service

--- a/tasks/requirements_debian.yml
+++ b/tasks/requirements_debian.yml
@@ -4,8 +4,8 @@
     name:
       - python3
       - python3-dev
-      - python3-pip
       - python3-wheel
+      - virtualenv
     state: present
   tags:
     - pretalx

--- a/templates/pretalx-worker.service.j2
+++ b/templates/pretalx-worker.service.j2
@@ -5,9 +5,8 @@ After=network.target
 [Service]
 User={{ pretalx_system_user_prefix }}%i
 Group={{ pretalx_system_user_prefix }}%i
-WorkingDirectory=/home/{{ pretalx_system_user_prefix }}%i/.local/lib/python{{ pretalx_system_python_version }}/site-packages/pretalx
-ExecStart=/home/{{ pretalx_system_user_prefix }}%i/.local/bin/celery -A pretalx.celery_app worker -l info
-WorkingDirectory=/home/{{ pretalx_system_user_prefix }}%i
+ExecStart={{ pretalx_virtualenv }}/bin/celery -A pretalx.celery_app worker -l info
+WorkingDirectory={{ pretalx_virtualenv }}/lib/python{{ pretalx_system_python_version }}/site-packages/pretalx
 Restart=on-failure
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID

--- a/templates/pretalx.service.j2
+++ b/templates/pretalx.service.j2
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 User={{ pretalx_system_user_prefix }}%i
 Group={{ pretalx_system_user_prefix }}%i
-WorkingDirectory=/home/{{ pretalx_system_user_prefix }}%i/.local/lib/python{{ pretalx_system_python_version }}/site-packages/pretalx
-ExecStart=/home/{{ pretalx_system_user_prefix }}%i/.local/bin/gunicorn --bind unix:/run/gunicorn/pretalx_%i --workers {{ pretalx_service_workers }}  --max-requests {{ pretalx_service_workers_max_requests }}  --max-requests-jitter {{ pretalx_service_workers_max_requests_jitter }} pretalx.wsgi
+WorkingDirectory={{ pretalx_virtualenv }}/lib/python{{ pretalx_system_python_version }}/site-packages/pretalx
+ExecStart={{ pretalx_virtualenv }}/bin/gunicorn --bind unix:/run/gunicorn/pretalx_%i --workers {{ pretalx_service_workers }}  --max-requests {{ pretalx_service_workers_max_requests }}  --max-requests-jitter {{ pretalx_service_workers_max_requests_jitter }} pretalx.wsgi
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID


### PR DESCRIPTION
This is an improved version of #44 : it will create a python environment per instance rather than using using pip user install.

It actually covers the points mentioned in the review there:
* npm stuff was added separately
* pretalx_python was added to the defaults
* I removed the omit statement to make sure only venv are used

