### PR TITLE
fix: install plugins with pips, supporting pyproject.toml

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,7 @@
     daemon_reload: true
 
 - name: Install pretalx plugins
-  shell: cd {{ pretalx_system_home }}/plugins/{{ item.name }} && {{ pretalx_python }} setup.py develop --user
+  shell: cd {{ pretalx_system_home }}/plugins/{{ item.name }} && {{ pretalx_python }} -m pip install -e .
   with_items: "{{ pretalx_plugins }}"
   become: true
   become_user: "{{ pretalx_system_user }}"


### PR DESCRIPTION
Some plugins are using pyproject.toml instead of setup.py for some time, which was not supported.

Example: https://github.com/pretalx/pretalx-media-ccc-de/commit/2f166581410e229b648941d4aa09534dfd4e53cf#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711